### PR TITLE
Add option to remove 'data' keys from relations

### DIFF
--- a/__tests__/mock.js
+++ b/__tests__/mock.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const data = {
+const dataWithRelationsDataKey = {
 	attribute: {
 		initial: {
 			id: 1,
@@ -335,6 +335,332 @@ const data = {
 	},
 };
 
+const dataWithoutRelationsDataKey = {
+	attribute: {
+		initial: {
+			id: 1,
+			attributes: {
+				title: 'Lorem',
+				createdAt: '2022-02-14T02:58:35.291Z',
+				updatedAt: '2022-02-16T01:25:00.014Z',
+				publishedAt: '2022-02-16T01:25:00.012Z',
+			},
+		},
+		expect: {
+			id: 1,
+			title: 'Lorem',
+			createdAt: '2022-02-14T02:58:35.291Z',
+			updatedAt: '2022-02-16T01:25:00.014Z',
+			publishedAt: '2022-02-16T01:25:00.012Z',
+		},
+	},
+	arrayWithAttributes: {
+		initial: [
+			{
+				id: 1,
+				attributes: {
+					title: 'Lorem',
+					createdAt: '2022-02-17T00:07:40.318Z',
+					updatedAt: '2022-02-17T04:59:39.055Z',
+					publishedAt: '2022-02-17T00:07:42.124Z',
+				},
+			},
+			{
+				id: 2,
+				attributes: {
+					title: 'Ispum',
+					createdAt: '2022-02-17T01:50:14.909Z',
+					updatedAt: '2022-02-18T01:12:39.781Z',
+					publishedAt: '2022-02-18T01:12:39.779Z',
+				},
+			},
+		],
+		expect: [
+			{
+				id: 1,
+				title: 'Lorem',
+				createdAt: '2022-02-17T00:07:40.318Z',
+				updatedAt: '2022-02-17T04:59:39.055Z',
+				publishedAt: '2022-02-17T00:07:42.124Z',
+			},
+			{
+				id: 2,
+				title: 'Ispum',
+				createdAt: '2022-02-17T01:50:14.909Z',
+				updatedAt: '2022-02-18T01:12:39.781Z',
+				publishedAt: '2022-02-18T01:12:39.779Z',
+			},
+		],
+	},
+	dataObject: {
+		initial: {
+			id: 1,
+			attributes: {
+				title: 'Lorem',
+				createdAt: '2022-02-17T00:29:00.833Z',
+				updatedAt: '2022-02-17T00:29:03.988Z',
+				publishedAt: '2022-02-17T00:29:03.986Z',
+				singleRelation: {
+					data: {
+						id: 1,
+						attributes: {
+							title: 'Ipsum',
+							createdAt: '2022-02-15T03:45:32.669Z',
+							updatedAt: '2022-02-17T00:30:02.573Z',
+							publishedAt: '2022-02-17T00:07:49.491Z',
+						},
+					},
+				},
+			},
+		},
+		expect: {
+			id: 1,
+			title: 'Lorem',
+			createdAt: '2022-02-17T00:29:00.833Z',
+			updatedAt: '2022-02-17T00:29:03.988Z',
+			publishedAt: '2022-02-17T00:29:03.986Z',
+			singleRelation: {
+				id: 1,
+				title: 'Ipsum',
+				createdAt: '2022-02-15T03:45:32.669Z',
+				updatedAt: '2022-02-17T00:30:02.573Z',
+				publishedAt: '2022-02-17T00:07:49.491Z',
+			},
+		},
+	},
+	dataArray: {
+		initial: {
+			id: 1,
+			attributes: {
+				title: 'Lorem',
+				createdAt: '2022-02-15T03:45:32.669Z',
+				updatedAt: '2022-02-17T00:30:02.573Z',
+				publishedAt: '2022-02-17T00:07:49.491Z',
+				manyRelation: {
+					data: [
+						{
+							id: 2,
+							attributes: {
+								title: 'Ipsum',
+								createdAt: '2022-02-14T02:57:55.918Z',
+								updatedAt: '2022-02-17T00:09:17.360Z',
+								publishedAt: '2022-02-17T00:09:13.399Z',
+								test: null,
+							},
+						},
+						{
+							id: 3,
+							attributes: {
+								title: 'Dolor',
+								createdAt: '2022-02-17T00:29:16.890Z',
+								updatedAt: '2022-02-18T00:56:28.909Z',
+								publishedAt: '2022-02-17T00:29:17.874Z',
+								test: '2022-02-03T05:00:00.000Z',
+							},
+						},
+					],
+				},
+			},
+		},
+		expect: {
+			id: 1,
+			title: 'Lorem',
+			createdAt: '2022-02-15T03:45:32.669Z',
+			updatedAt: '2022-02-17T00:30:02.573Z',
+			publishedAt: '2022-02-17T00:07:49.491Z',
+			manyRelation: [
+				{
+					id: 2,
+					title: 'Ipsum',
+					createdAt: '2022-02-14T02:57:55.918Z',
+					updatedAt: '2022-02-17T00:09:17.360Z',
+					publishedAt: '2022-02-17T00:09:13.399Z',
+					test: null,
+				},
+				{
+					id: 3,
+					title: 'Dolor',
+					createdAt: '2022-02-17T00:29:16.890Z',
+					updatedAt: '2022-02-18T00:56:28.909Z',
+					publishedAt: '2022-02-17T00:29:17.874Z',
+					test: '2022-02-03T05:00:00.000Z',
+				},
+			],
+		},
+	},
+	id: {
+		initial: {
+			id: 1,
+			attributes: {
+				title: 'Lorem',
+				createdAt: '2022-02-17T00:29:16.890Z',
+				updatedAt: '2022-02-18T00:56:28.909Z',
+				publishedAt: '2022-02-17T00:29:17.874Z',
+				test: '2022-02-03T05:00:00.000Z',
+				singleComponent: {
+					id: 2,
+					title: 'Ipsum',
+					singleRelation: {
+						data: {
+							id: 3,
+							attributes: {
+								title: 'Dolor',
+							},
+						},
+					},
+				},
+			},
+		},
+		expect: {
+			id: 1,
+			title: 'Lorem',
+			createdAt: '2022-02-17T00:29:16.890Z',
+			updatedAt: '2022-02-18T00:56:28.909Z',
+			publishedAt: '2022-02-17T00:29:17.874Z',
+			test: '2022-02-03T05:00:00.000Z',
+			singleComponent: {
+				id: 2,
+				title: 'Ipsum',
+				singleRelation: {
+					id: 3,
+					title: 'Dolor',
+				},
+			},
+		},
+	},
+	arrayWithIds: {
+		initial: {
+			id: 1,
+			attributes: {
+				title: 'Lorem',
+				createdAt: '2022-02-17T00:29:16.890Z',
+				updatedAt: '2022-02-18T00:56:28.909Z',
+				publishedAt: '2022-02-17T00:29:17.874Z',
+				test: '2022-02-03T05:00:00.000Z',
+				repeatableComponent: [
+					{
+						id: 2,
+						title: 'Ipsum',
+						singleRelation: {
+							data: {
+								id: 3,
+								attributes: {
+									title: 'Dolor',
+								},
+							},
+						},
+					},
+					{
+						id: 4,
+						title: 'Sat',
+						manyRelation: {
+							data: [
+								{
+									id: 5,
+									attributes: {
+										title: 'Amet',
+									},
+								},
+								{
+									id: 6,
+									attributes: {
+										title: 'consectetur',
+									},
+								},
+							],
+						},
+					},
+				],
+			},
+		},
+		expect: {
+			id: 1,
+			title: 'Lorem',
+			createdAt: '2022-02-17T00:29:16.890Z',
+			updatedAt: '2022-02-18T00:56:28.909Z',
+			publishedAt: '2022-02-17T00:29:17.874Z',
+			test: '2022-02-03T05:00:00.000Z',
+			repeatableComponent: [
+				{
+					id: 2,
+					title: 'Ipsum',
+					singleRelation: {
+						id: 3,
+						title: 'Dolor',
+					},
+				},
+				{
+					id: 4,
+					title: 'Sat',
+					manyRelation: [
+						{
+							id: 5,
+							title: 'Amet',
+						},
+						{
+							id: 6,
+							title: 'consectetur',
+						},
+					],
+				},
+			],
+		},
+	},
+	provider: {
+		initial: {
+			id: 1,
+			attributes: {
+				title: 'Lorem',
+				createdAt: '2022-02-17T01:50:38.599Z',
+				updatedAt: '2022-02-18T02:05:56.635Z',
+				publishedAt: '2022-02-18T02:05:56.628Z',
+				singleMedia: {
+					id: 2,
+					provider: 'local',
+				},
+			},
+		},
+		expect: {
+			id: 1,
+			title: 'Lorem',
+			createdAt: '2022-02-17T01:50:38.599Z',
+			updatedAt: '2022-02-18T02:05:56.635Z',
+			publishedAt: '2022-02-18T02:05:56.628Z',
+			singleMedia: {
+				id: 2,
+				provider: 'local',
+			},
+		},
+	},
+	arrayWithProviders: {
+		initial: {
+			id: 1,
+			attributes: {
+				title: 'Lorem',
+				createdAt: '2022-02-17T01:50:38.599Z',
+				updatedAt: '2022-02-18T02:05:56.635Z',
+				publishedAt: '2022-02-18T02:05:56.628Z',
+				singleMedia: [
+					{ id: 2, provider: 'local' },
+					{ id: 3, provider: 'local' },
+				],
+			},
+		},
+		expect: {
+			id: 1,
+			title: 'Lorem',
+			createdAt: '2022-02-17T01:50:38.599Z',
+			updatedAt: '2022-02-18T02:05:56.635Z',
+			publishedAt: '2022-02-18T02:05:56.628Z',
+			singleMedia: [
+				{ id: 2, provider: 'local' },
+				{ id: 3, provider: 'local' },
+			],
+		},
+	},
+};
+
 module.exports = {
-	data,
+	dataWithRelationsDataKey,
+	dataWithoutRelationsDataKey,
 };

--- a/__tests__/remove-attributes.spec.js
+++ b/__tests__/remove-attributes.spec.js
@@ -1,65 +1,181 @@
 'use strict';
 
 const transformService = require('../server/services/transform-service');
-const { data } = require('./mock');
+const { dataWithRelationsDataKey, dataWithoutRelationsDataKey } = require('./mock');
 
-const { removeAttributeKey } = transformService();
+const serviceWithRelationsDataKey = transformService({ keepRelationsDataAttribute: true });
+const serviceWithoutRelationsDataKey = transformService({ keepRelationsDataAttribute: false });
 
-describe('removeAttributes', () => {
+describe('removeAttributes with data key in relations', () => {
 	// single
 	test('object with attributes property', () => {
-		const result = removeAttributeKey(data.attribute.initial);
+		const result = serviceWithRelationsDataKey.removeAttributeKey(
+			dataWithRelationsDataKey.attribute.initial
+		);
 		expect(result).toBeDefined();
-		expect(result).toEqual(data.attribute.expect);
+		expect(result).toEqual(dataWithRelationsDataKey.attribute.expect);
 	});
 
 	// collection
 	test('array of of objects containing an attributes property', () => {
-		const result = removeAttributeKey(data.arrayWithAttributes.initial);
+		const result = serviceWithRelationsDataKey.removeAttributeKey(
+			dataWithRelationsDataKey.arrayWithAttributes.initial
+		);
 		expect(result).toBeDefined();
-		expect(result).toEqual(data.arrayWithAttributes.expect);
+		expect(result).toEqual(dataWithRelationsDataKey.arrayWithAttributes.expect);
 	});
 
 	// single relation
 	test('object with data property of type object', () => {
-		const result = removeAttributeKey(data.dataObject.initial);
+		const result = serviceWithRelationsDataKey.removeAttributeKey(
+			dataWithRelationsDataKey.dataObject.initial
+		);
 		expect(result).toBeDefined();
-		expect(result).toEqual(data.dataObject.expect);
+		expect(result).toEqual(dataWithRelationsDataKey.dataObject.expect);
 	});
 
 	// multiple relation
 	test('object with data property of type array', () => {
-		const result = removeAttributeKey(data.dataArray.initial);
+		const result = serviceWithRelationsDataKey.removeAttributeKey(
+			dataWithRelationsDataKey.dataArray.initial
+		);
 		expect(result).toBeDefined();
-		expect(result).toEqual(data.dataArray.expect);
+		expect(result).toEqual(dataWithRelationsDataKey.dataArray.expect);
 	});
 
 	// single component
 	test('object with id property', () => {
-		const result = removeAttributeKey(data.id.initial);
+		const result = serviceWithRelationsDataKey.removeAttributeKey(
+			dataWithRelationsDataKey.id.initial
+		);
 		expect(result).toBeDefined();
-		expect(result).toEqual(data.id.expect);
+		expect(result).toEqual(dataWithRelationsDataKey.id.expect);
 	});
 
 	// multiple components
 	// dynamic zone
 	test('array of objects containing an id property', () => {
-		const result = removeAttributeKey(data.arrayWithIds.initial);
+		const result = serviceWithRelationsDataKey.removeAttributeKey(
+			dataWithRelationsDataKey.arrayWithIds.initial
+		);
 		expect(result).toBeDefined();
-		expect(result).toEqual(data.arrayWithIds.expect);
+		expect(result).toEqual(dataWithRelationsDataKey.arrayWithIds.expect);
 	});
 
 	// skip single media
 	test('object with provider property', () => {
-		const result = removeAttributeKey(data.provider.initial);
+		const result = serviceWithRelationsDataKey.removeAttributeKey(
+			dataWithRelationsDataKey.provider.initial
+		);
 		expect(result).toBeDefined();
-		expect(result).toEqual(data.provider.expect);
+		expect(result).toEqual(dataWithRelationsDataKey.provider.expect);
 	});
 
 	// skip multi media
 	test('array of objects containing a provider property', () => {
-		const result = removeAttributeKey(data.arrayWithProviders.initial);
+		const result = serviceWithRelationsDataKey.removeAttributeKey(
+			dataWithRelationsDataKey.arrayWithProviders.initial
+		);
 		expect(result).toBeDefined();
-		expect(result).toEqual(data.arrayWithProviders.expect);
+		expect(result).toEqual(dataWithRelationsDataKey.arrayWithProviders.expect);
+	});
+});
+
+describe('removeAttributes without data key in relations', () => {
+	// single
+	test('object with attributes property', () => {
+		const result = serviceWithoutRelationsDataKey.removeAttributeKey(
+			dataWithoutRelationsDataKey.attribute.initial,
+			{
+				keepRelationsDataAttribute: false,
+			}
+		);
+		expect(result).toBeDefined();
+		expect(result).toEqual(dataWithoutRelationsDataKey.attribute.expect);
+	});
+
+	// collection
+	test('array of of objects containing an attributes property', () => {
+		const result = serviceWithoutRelationsDataKey.removeAttributeKey(
+			dataWithoutRelationsDataKey.arrayWithAttributes.initial,
+			{
+				keepRelationsDataAttribute: false,
+			}
+		);
+		expect(result).toBeDefined();
+		expect(result).toEqual(dataWithoutRelationsDataKey.arrayWithAttributes.expect);
+	});
+
+	// single relation
+	test('object with data property of type object', () => {
+		const result = serviceWithoutRelationsDataKey.removeAttributeKey(
+			dataWithoutRelationsDataKey.dataObject.initial,
+			{
+				keepRelationsDataAttribute: false,
+			}
+		);
+		expect(result).toBeDefined();
+		expect(result).toEqual(dataWithoutRelationsDataKey.dataObject.expect);
+	});
+
+	// multiple relation
+	test('object with data property of type array', () => {
+		const result = serviceWithoutRelationsDataKey.removeAttributeKey(
+			dataWithoutRelationsDataKey.dataArray.initial,
+			{
+				keepRelationsDataAttribute: false,
+			}
+		);
+		expect(result).toBeDefined();
+		expect(result).toEqual(dataWithoutRelationsDataKey.dataArray.expect);
+	});
+
+	// single component
+	test('object with id property', () => {
+		const result = serviceWithoutRelationsDataKey.removeAttributeKey(
+			dataWithoutRelationsDataKey.id.initial,
+			{
+				keepRelationsDataAttribute: false,
+			}
+		);
+		expect(result).toBeDefined();
+		expect(result).toEqual(dataWithoutRelationsDataKey.id.expect);
+	});
+
+	// multiple components
+	// dynamic zone
+	test('array of objects containing an id property', () => {
+		const result = serviceWithoutRelationsDataKey.removeAttributeKey(
+			dataWithoutRelationsDataKey.arrayWithIds.initial,
+			{
+				keepRelationsDataAttribute: false,
+			}
+		);
+		expect(result).toBeDefined();
+		expect(result).toEqual(dataWithoutRelationsDataKey.arrayWithIds.expect);
+	});
+
+	// skip single media
+	test('object with provider property', () => {
+		const result = serviceWithoutRelationsDataKey.removeAttributeKey(
+			dataWithoutRelationsDataKey.provider.initial,
+			{
+				keepRelationsDataAttribute: false,
+			}
+		);
+		expect(result).toBeDefined();
+		expect(result).toEqual(dataWithoutRelationsDataKey.provider.expect);
+	});
+
+	// skip multi media
+	test('array of objects containing a provider property', () => {
+		const result = serviceWithoutRelationsDataKey.removeAttributeKey(
+			dataWithoutRelationsDataKey.arrayWithProviders.initial,
+			{
+				keepRelationsDataAttribute: false,
+			}
+		);
+		expect(result).toBeDefined();
+		expect(result).toEqual(dataWithoutRelationsDataKey.arrayWithProviders.expect);
 	});
 });

--- a/server/middleware/transform.js
+++ b/server/middleware/transform.js
@@ -20,7 +20,9 @@ const transform = async (strapi, ctx, next) => {
 
 		// ensure no error returned.
 		if (data) {
-			ctx.body['data'] = getPluginService(strapi, 'transformService').removeAttributeKey(data);
+			ctx.body['data'] = getPluginService(strapi, 'transformService').removeAttributeKey(data, {
+				keepRelationsDataAttribute: settings.keepRelationsDataAttribute,
+			});
 		}
 	}
 };

--- a/server/services/transform-service.js
+++ b/server/services/transform-service.js
@@ -3,7 +3,11 @@
 const _ = require('lodash');
 const { removeObjectKey } = require('../util/removeObjectKey');
 
-module.exports = () => ({
+const defaultOptions = {
+	keepRelationsDataAttribute: true,
+};
+
+module.exports = (options = defaultOptions) => ({
 	removeAttributeKey: function transform(data) {
 		// single
 		if (_.has(data, 'attributes')) {
@@ -25,12 +29,25 @@ module.exports = () => ({
 			if (_.has(value, 'data')) {
 				// single
 				if (_.isObject(value.data)) {
-					data[key]['data'] = transform(value.data);
+					if (options.keepRelationsDataAttribute) {
+						data[key]['data'] = transform(value.data);
+					} else {
+						data[key] = transform(value.data);
+					}
 				}
 
 				// many
 				if (_.isArray(value.data)) {
-					data[key]['data'] = value.data.map((e) => transform(e));
+					if (options.keepRelationsDataAttribute) {
+						data[key]['data'] = value.data.map((e) => transform(e));
+					} else {
+						data[key] = value.data.map((e) => transform(e));
+					}
+				}
+
+				// null data
+				if (!options.keepRelationsDataAttribute && value.data === null) {
+					data[key] = null;
 				}
 			}
 


### PR DESCRIPTION
Thanks for providing this plugin!
As it was a need for us I forked it and added an option to remove the unnecessary "data" keys everywhere. I know it might be a problem in the future as I believe I read somewhere the Strapi team wants to put "meta" information inside relations. Hopefully they (you?) will listen to the community and provide an option to disable these things.
I'm on a short timeline so I went pretty fast here, there is some redundancy in the tests file, feel free to adjust/comment. You're free to take whatever you want or nothing from this :)