### PR TITLE
fix(transformResponse) handle empty relational data

### DIFF
--- a/__tests__/all-response-transforms.spec.js
+++ b/__tests__/all-response-transforms.spec.js
@@ -14,11 +14,23 @@ describe('All response transforms', () => {
 		expect(result).toEqual(allResponseTransforms.dataObject);
 	});
 
+	test('object with data property of type null', () => {
+		const result = transformResponse(transformOptions, initial.dataWithNull);
+		expect(result).toBeDefined();
+		expect(result).toEqual(allResponseTransforms.dataWithNull);
+	});
+
 	// multiple relation
 	test('object with data property of type array', () => {
 		const result = transformResponse(transformOptions, initial.dataArray);
 		expect(result).toBeDefined();
 		expect(result).toEqual(allResponseTransforms.dataArray);
+	});
+
+	test('object with data property of type array with no length', () => {
+		const result = transformResponse(transformOptions, initial.dataWithEmptyArray);
+		expect(result).toBeDefined();
+		expect(result).toEqual(allResponseTransforms.dataWithEmptyArray);
 	});
 
 	// single component

--- a/__tests__/mock/all-response-transforms.js
+++ b/__tests__/mock/all-response-transforms.js
@@ -61,6 +61,22 @@ module.exports = {
 			},
 		],
 	},
+	dataWithNull: {
+		id: 1,
+		title: 'Lorem',
+		createdAt: '2022-02-17T00:29:00.833Z',
+		updatedAt: '2022-02-17T00:29:03.988Z',
+		publishedAt: '2022-02-17T00:29:03.986Z',
+		singleRelation: null,
+	},
+	dataWithEmptyArray: {
+		id: 1,
+		title: 'Lorem',
+		createdAt: '2022-02-15T03:45:32.669Z',
+		updatedAt: '2022-02-17T00:30:02.573Z',
+		publishedAt: '2022-02-17T00:07:49.491Z',
+		manyRelation: [],
+	},
 	id: {
 		id: 1,
 		title: 'Lorem',

--- a/__tests__/mock/initial.js
+++ b/__tests__/mock/initial.js
@@ -81,6 +81,30 @@ module.exports = {
 			},
 		},
 	},
+	dataWithNull: {
+		id: 1,
+		attributes: {
+			title: 'Lorem',
+			createdAt: '2022-02-17T00:29:00.833Z',
+			updatedAt: '2022-02-17T00:29:03.988Z',
+			publishedAt: '2022-02-17T00:29:03.986Z',
+			singleRelation: {
+				data: null,
+			},
+		},
+	},
+	dataWithEmptyArray: {
+		id: 1,
+		attributes: {
+			title: 'Lorem',
+			createdAt: '2022-02-15T03:45:32.669Z',
+			updatedAt: '2022-02-17T00:30:02.573Z',
+			publishedAt: '2022-02-17T00:07:49.491Z',
+			manyRelation: {
+				data: [],
+			},
+		},
+	},
 	id: {
 		id: 1,
 		attributes: {

--- a/__tests__/mock/remove-attributes.js
+++ b/__tests__/mock/remove-attributes.js
@@ -65,6 +65,26 @@ module.exports = {
 			],
 		},
 	},
+	dataWithNull: {
+		id: 1,
+		title: 'Lorem',
+		createdAt: '2022-02-17T00:29:00.833Z',
+		updatedAt: '2022-02-17T00:29:03.988Z',
+		publishedAt: '2022-02-17T00:29:03.986Z',
+		singleRelation: {
+			data: null,
+		},
+	},
+	dataWithEmptyArray: {
+		id: 1,
+		title: 'Lorem',
+		createdAt: '2022-02-15T03:45:32.669Z',
+		updatedAt: '2022-02-17T00:30:02.573Z',
+		publishedAt: '2022-02-17T00:07:49.491Z',
+		manyRelation: {
+			data: [],
+		},
+	},
 	id: {
 		id: 1,
 		title: 'Lorem',

--- a/__tests__/mock/remove-data.js
+++ b/__tests__/mock/remove-data.js
@@ -77,6 +77,26 @@ module.exports = {
 			],
 		},
 	},
+	dataWithNull: {
+		id: 1,
+		attributes: {
+			title: 'Lorem',
+			createdAt: '2022-02-17T00:29:00.833Z',
+			updatedAt: '2022-02-17T00:29:03.988Z',
+			publishedAt: '2022-02-17T00:29:03.986Z',
+			singleRelation: null,
+		},
+	},
+	dataWithEmptyArray: {
+		id: 1,
+		attributes: {
+			title: 'Lorem',
+			createdAt: '2022-02-15T03:45:32.669Z',
+			updatedAt: '2022-02-17T00:30:02.573Z',
+			publishedAt: '2022-02-17T00:07:49.491Z',
+			manyRelation: [],
+		},
+	},
 	id: {
 		id: 1,
 		attributes: {

--- a/__tests__/remove-attributes.spec.js
+++ b/__tests__/remove-attributes.spec.js
@@ -14,11 +14,23 @@ describe('removeAttributesKey', () => {
 		expect(result).toEqual(removeAttributesKey.dataObject);
 	});
 
+	test('object with data property of type null', () => {
+		const result = transformResponse(transformOptions, initial.dataWithNull);
+		expect(result).toBeDefined();
+		expect(result).toEqual(removeAttributesKey.dataWithNull);
+	});
+
 	// multiple relation
 	test('object with data property of type array', () => {
 		const result = transformResponse(transformOptions, initial.dataArray);
 		expect(result).toBeDefined();
 		expect(result).toEqual(removeAttributesKey.dataArray);
+	});
+
+	test('object with data property of type array with no length', () => {
+		const result = transformResponse(transformOptions, initial.dataWithEmptyArray);
+		expect(result).toBeDefined();
+		expect(result).toEqual(removeAttributesKey.dataWithEmptyArray);
 	});
 
 	// single component

--- a/__tests__/remove-data.spec.js
+++ b/__tests__/remove-data.spec.js
@@ -14,11 +14,23 @@ describe('removeDataKey', () => {
 		expect(result).toEqual(removeDataKey.dataObject);
 	});
 
+	test('object with data property of type null', () => {
+		const result = transformResponse(transformOptions, initial.dataWithNull);
+		expect(result).toBeDefined();
+		expect(result).toEqual(removeDataKey.dataWithNull);
+	});
+
 	// multiple relation
 	test('object with data property of type array', () => {
 		const result = transformResponse(transformOptions, initial.dataArray);
 		expect(result).toBeDefined();
 		expect(result).toEqual(removeDataKey.dataArray);
+	});
+
+	test('object with data property of type array with no length', () => {
+		const result = transformResponse(transformOptions, initial.dataWithEmptyArray);
+		expect(result).toBeDefined();
+		expect(result).toEqual(removeDataKey.dataWithEmptyArray);
 	});
 
 	// single component

--- a/server/services/transform-service.js
+++ b/server/services/transform-service.js
@@ -47,7 +47,7 @@ module.exports = () => ({
 
 			// relation(s)
 			if (_.has(value, 'data')) {
-				let relation;
+				let relation = null;
 				// single
 				if (_.isObject(value.data)) {
 					relation = traverse(transforms, value.data);


### PR DESCRIPTION
This PR introduces the following change(s)
- account for empty (null, []) relational data in transform response

### Related Issue(s)
- Resolves #18 