### PR TITLE
feat(transform): skip requests with `Strapi-Transformer-Ignore` true 

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,29 @@ This response transform will remove the data key from the response and shift the
 }
 ```
 
+## Supported Headers
+
+| Name | Description | Type | Default | Required |
+| -------- | ----------- | ---- | ------- | -------- |
+| Strapi-Transformer-Ignore | Indicates if transform should be ignored for this request | String | 'false' | No |
+
+### CORS
+By default CORS will block any custom headers. To enable custom headers to be accepted the [cors middlware](https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/required/middlewares.html#cors) headers property must include the custom header(s) that should be accepted.
+
+Example CORS configuration
+```js
+module.exports = [
+  // ..
+  {
+    name: 'strapi::cors',
+    config: {
+      headers: ['Strapi-Transformer-Ignore'],
+    },
+  },
+  // ..
+]
+```
+
 ## Bugs
 
 If any bugs are found please report them as a [Github Issue](https://github.com/ComfortablyCoding/strapi-plugin-transformer/issues)

--- a/server/middleware/transform.js
+++ b/server/middleware/transform.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const { getPluginService } = require('../util/getPluginService');
 const { isAPIRequest } = require('../util/isAPIRequest');
 
@@ -7,6 +8,12 @@ const transform = async (strapi, ctx, next) => {
 	const settings = getPluginService('settingsService').get();
 
 	await next();
+
+	// skip any requests that have ignore header
+	const transformIgnoreHeader = _.get(ctx, ['headers', 'strapi-transformer-ignore'], 'false');
+	if (transformIgnoreHeader === 'true') {
+		return;
+	}
 
 	// ensure body exists, occurs on non existent route
 	if (!ctx.body) {


### PR DESCRIPTION
This PR introduces support for a `Strapi-Transformer-Ignore` header which enables disabling transforms on a per request basis.