### PR TITLE
feat: add hook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ module.exports = ({ env }) => ({
 | responseTransforms | The transformations to enable for the API response | Object | undefined | No |
 | responseTransforms.removeAttributesKey | Removes the attributes key from the response | Boolean | false | No |
 | responseTransforms.removeDataKey | Removes the data key from the response | Boolean | false | No |
-
+| hooks | The hooks to enable for the plugin | Object | undefined | No |
+| hooks.preResponseTransform | A hook that executes before the Response Transforms are applied | Function | None | No |
+| hooks.postResponseTransform | A hook that executes after the Response Transforms are applied | Function | None | No |
 ## Usage
 
 Once the plugin has been installed, configured and enabled any request to the Strapi API will be auto transformed.

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -3,7 +3,13 @@
 const { pluginConfigSchema } = require('./schema');
 
 module.exports = {
-	default: () => ({ prefix: '/api/' }),
+	default: () => ({
+		prefix: '/api/',
+		hooks: {
+			preResponseTransform: (ctx) => {},
+			postResponseTransform: (ctx) => {},
+		},
+	}),
 	validator: async (config) => {
 		await pluginConfigSchema.validate(config);
 	},

--- a/server/middleware/transform.js
+++ b/server/middleware/transform.js
@@ -21,14 +21,19 @@ const transform = async (strapi, ctx, next) => {
 	}
 
 	// only process api requests.
-	if (isAPIRequest(ctx)) {
-		const { data } = ctx.body;
-
-		// ensure no error returned.
-		if (data) {
-			ctx.body['data'] = getPluginService('transformService').response(settings, data);
-		}
+	if (!isAPIRequest(ctx)) {
+		return;
 	}
+
+	// ensure no error returned.
+	if (!ctx.body.data) {
+		return;
+	}
+
+	// execute response transforms
+	settings.hooks.preResponseTransform(ctx);
+	ctx.body['data'] = getPluginService('transformService').response(settings, ctx.body.data);
+	settings.hooks.postResponseTransform(ctx);
 };
 
 module.exports = ({ strapi }) => {


### PR DESCRIPTION
This PR adds support for hooks. The current supported hooks are 

- `preResponseTransform`: Execued before the Response Transforms have run
- `postResponseTransform`: Execued after the Response Transforms have run

Resolves #54