### PR TITLE
feat(middleware): add denyList support

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ This response transform will remove the data key from the response and shift the
 
 #### After
 
-
 ```json
 {
   "data": {
@@ -200,6 +199,28 @@ This response transform will remove the data key from the response and shift the
     },
   },
   "meta": {},
+}
+```
+
+### Auto wrap the body content with a data key
+
+This request transform will auto wrap the body content with a surrounding data key on all enabled routes.
+
+#### Before
+
+```json
+{
+  "title": "Lorem Ipsum",
+}
+```
+
+#### After
+
+```json
+{
+  "data": {
+    "title": "Lorem Ipsum",
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ module.exports = ({ env }) => ({
       responseTransforms: {
         removeAttributesKey: true,
         removeDataKey: true,
+      },
+      requestTransforms : {
+        wrapBodyWithDataKey: true
+      },
+      hooks: {
+        preResponseTransform : (ctx) => console.log('hello from the preResponseTransform hook!'),
+        postResponseTransform : (ctx) => console.log('hello from the postResponseTransform hook!')
+      },
+      denyList: {
+        'api::article.article': true,
+        'api::category.category': {
+          'GET':true,
+        }
       }
     }
   },
@@ -62,10 +75,13 @@ module.exports = ({ env }) => ({
 | responseTransforms.removeAttributesKey | Removes the attributes key from the response | Boolean | false | No |
 | responseTransforms.removeDataKey | Removes the data key from the response | Boolean | false | No |
 | requestTransforms | The transformations to enable for an API request | Object | undefined | No |
-| responseTransforms.wrapBodyWithDataKey | Auto wraps the body of PUT and POST requests with a data key | Boolean | false | No |
+| requestTransforms.wrapBodyWithDataKey | Auto wraps the body of PUT and POST requests with a data key | Boolean | false | No |
 | hooks | The hooks to enable for the plugin | Object | undefined | No |
 | hooks.preResponseTransform | A hook that executes before the Response Transforms are applied | Function | None | No |
 | hooks.postResponseTransform | A hook that executes after the Response Transforms are applied | Function | None | No |
+| denyList | A list of content type uids that the transforms should ignore | Object | None | No |
+| denyList[uid] | THe uid of the content type to ignore | Boolean or Object | false | No |
+| denyList[uid].method | The specific method of the uid to ignore | Boolean | false | No |
 ## Usage
 
 Once the plugin has been installed, configured and enabled any request to the Strapi API will be auto transformed.

--- a/server/register.js
+++ b/server/register.js
@@ -3,8 +3,11 @@
 const _ = require('lodash');
 
 const { transform } = require('./middleware/transform');
+const { getPluginService } = require('./util/getPluginService');
 
 module.exports = ({ strapi }) => {
+	const settings = getPluginService('settingsService').get();
+
 	// register transforms on all api routes
 	const apis = _.get(strapi, ['api'], {});
 	for (const ct in apis) {
@@ -12,8 +15,22 @@ module.exports = ({ strapi }) => {
 			continue;
 		}
 
+		// skip any uids in denylist that are completely denied
+		const uid = apis[ct].contentTypes[ct].uid;
+		const isDeniedUID = _.get(settings, ['denyList', uid], false);
+		if (isDeniedUID && typeof isDeniedUID === 'boolean') {
+			continue;
+		}
+
 		const apiRoutes = _.get(apis, [ct, 'routes', ct, 'routes'], []);
 		for (let i = 0; i < apiRoutes.length; i++) {
+			// skip any methods in deny list for this uid
+			const method = apiRoutes[i].method;
+			const isDeniedMethod = _.get(settings, ['denyList', uid, method], false);
+			if (isDeniedMethod) {
+				continue;
+			}
+
 			// ensure path exists
 			if (!_.has(apiRoutes[i], 'config')) {
 				_.set(strapi, ['api', ct, 'routes', ct, 'routes', i, 'config'], {});


### PR DESCRIPTION
This PR introduces the denyList feature. It enables users to specify which API endoints or API endpoint methods should be ignore by this plugin.