### PR TITLE
Updating default config

### DIFF
--- a/server/config/index.js
+++ b/server/config/index.js
@@ -4,10 +4,21 @@ const { pluginConfigSchema } = require('./schema');
 
 module.exports = {
 	default: () => ({
+		responseTransforms: {
+			removeAttributesKey: false,
+			removeDataKey: false,
+		},
+			requestTransforms: {
+			wrapBodyWithDataKey: false,
+		},
 		hooks: {
 			preResponseTransform: () => {},
 			postResponseTransform: () => {},
 		},
+		contentTypeFilter: {
+			mode: "allow",
+			uids: {}
+		  },
 	}),
 	validator: (config) => {
 		pluginConfigSchema.validateSync(config);


### PR DESCRIPTION
Adding in the default config, so that strapi can merge the transformer config correctly with out the default keys the values dont get merged in and the plugin doesn't register the middleware.

as per https://docs.strapi.io/developer-docs/latest/setup-deployment-guides/configurations/optional/plugins.html#graphql-configuration

config -> Optional	Used to override default plugin configuration (defined in strapi-server.js)