### PR TITLE
feat: add plugin transform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ module.exports = ({ env }) => ({
         }
       },
       plugins: {
-        uids: {
+        ids: {
           'slugify': true,
         }
       }
@@ -106,7 +106,7 @@ module.exports = ({ env }) => ({
 | contentTypeFilter.uids | The uids to filter | Object | {} | No |
 | plugins | The plugins to deny or allow the middleware to be regiestered on. Defaults to deny all plugins | Object | N/A | No |
 | plugins.mode | The filter mode. Current supported modes are `none`, `allow` or `deny` | String | 'none' | No |
-| plugins.uids | The plugin ids to filter. The plugin id is the name you set in the `plugins.js` file | Object | {} | No |
+| plugins.ids | The plugin ids to filter. The plugin id is the name you set in the `plugins.js` file | Object | {} | No |
 ## Usage
 
 Once the plugin has been installed, configured and enabled any request to the Strapi API will be auto transformed.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,21 @@ yarn add strapi-plugin-transformer
 
 The plugin configuration is stored in a config file located at `./config/plugins.js`. If this file doesn't exists, you will need to create it.
 
-A sample configuration
+### Minimal Configuration
+
+
+```javascript
+module.exports = ({ env }) => ({
+  // ..
+ 'transformer': {
+    enabled: true,
+    config: {}
+  },
+  // ..
+});
+```
+
+### Sample configuration
 
 ```javascript
 module.exports = ({ env }) => ({
@@ -61,6 +75,11 @@ module.exports = ({ env }) => ({
             'GET':true,
           }
         }
+      },
+      plugins: {
+        uids: {
+          'slugify': true,
+        }
       }
     }
   },
@@ -83,10 +102,11 @@ module.exports = ({ env }) => ({
 | hooks.preResponseTransform | A hook that executes before the Response Transforms are applied | Function | () => {} | No |
 | hooks.postResponseTransform | A hook that executes after the Response Transforms are applied | Function | () => {} | No |
 | contentTypeFilter | The content types to deny or allow the middleware to be regiestered on. Defaults to allow all content types | Object | N/A | No |
-| cotentTypeFilter.mode | The filter mode. Current supported modes are `none`, `allow` or `deny` | String | 'none' | No |
+| contentTypeFilter.mode | The filter mode. Current supported modes are `none`, `allow` or `deny` | String | 'none' | No |
 | contentTypeFilter.uids | The uids to filter | Object | {} | No |
-| denyList.uids[uid] | The uid of the content type to filter | Boolean or Object | false | No |
-| denyList.uids[uid].method | The specific method of the uid to filter | Boolean | false | No |
+| plugins | The plugins to deny or allow the middleware to be regiestered on. Defaults to deny all plugins | Object | N/A | No |
+| plugins.mode | The filter mode. Current supported modes are `none`, `allow` or `deny` | String | 'none' | No |
+| plugins.uids | The plugin ids to filter. The plugin id is the name you set in the `plugins.js` file | Object | {} | No |
 ## Usage
 
 Once the plugin has been installed, configured and enabled any request to the Strapi API will be auto transformed.

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -19,6 +19,10 @@ module.exports = {
 			mode: 'none',
 			uids: {},
 		},
+		plugins: {
+			mode: 'none',
+			ids: {},
+		},
 	}),
 	validator: (config) => {
 		pluginConfigSchema.validateSync(config);

--- a/server/config/schema.js
+++ b/server/config/schema.js
@@ -28,6 +28,10 @@ const pluginConfigSchema = yup.object().shape({
 		mode: yup.string().oneOf(['allow', 'deny', 'none']),
 		uids: yup.object(),
 	}),
+	plugins: yup.object().shape({
+		mode: yup.string().oneOf(['allow', 'deny', 'none']),
+		ids: yup.object(),
+	}),
 });
 
 module.exports = {


### PR DESCRIPTION
This PR adds support for adding the transform middleware to plugins. It also enables custom routes to be transformed.

A new setting property has been added to control which plugins should be allowed
```javascript
module.exports = ({ env }) => ({
  // ..
 'transformer': {
    enabled: true,
    config: {
     plugins:{
       ids :{
         'slugify':true
       }
     }
    }
  },
  // ..
});
```

Resolves
#80
#77