### PR TITLE
allow transforms to ignore routes

### DIFF
--- a/server/services/transform-service/request.js
+++ b/server/services/transform-service/request.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const { matchRule } = require('./util');
 
 /**
  *
@@ -11,7 +12,11 @@ const _ = require('lodash');
 function transformRequest(transforms = {}, ctx) {
 	// wrapBodyWithDataKey
 	if (transforms.wrapBodyWithDataKey) {
-		wrapBodyWithDataKey(ctx);
+		let wrap = true
+		if (transforms.ignoredRoutes !== undefined) {
+			wrap = transforms.ignoredRoutes.filter((r) => matchRule(ctx.request.url, r) === true ).length === 0
+		};
+		wrap &&	wrapBodyWithDataKey(ctx)
 	}
 }
 

--- a/server/services/transform-service/util.js
+++ b/server/services/transform-service/util.js
@@ -5,6 +5,12 @@ function removeObjectKey(object, key) {
 	};
 }
 
+const matchRule = (str, rule) => {
+	const escapeRegex = (str) => str.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
+	return new RegExp("^" + rule.split("*").map(escapeRegex).join(".*") + "$").test(str);
+  }
+
 module.exports = {
 	removeObjectKey,
+	matchRule
 };


### PR DESCRIPTION
Not sure if this is the best way to go about this, but this plugin doesn't play nicely with the user-permissions plugin when calling the forgot-password, reset-password, etc auth endpoints when `requestTransforms.wrapBodyWithDataKey` is set to `true` - results in 
```
{
    "data": null,
    "error": {
        "status": 400,
        "name": "ValidationError",
        "message": "2 errors occurred",
        "details": {
            "errors": [
                {
                    "path": [
                        "email"
                    ],
                    "message": "email is a required field",
                    "name": "ValidationError"
                },
                {
                    "path": [],
                    "message": "this field has unspecified keys: data",
                    "name": "ValidationError"
                }
            ]
        }
    }
}
```

The following didn't work 
```
      contentTypeFilter: {
        mode: "deny",
        uids: {
          "plugin::users-permissions.auth.forgotPassword": true,
          "plugin::users-permissions.auth.resetPassword": true,
          "api::users-permissions.auth.forgotPassword": true,
          "api::users-permissions.auth.resetPassword": true,
        },
      },
```

This PR adds a list of ignored routes to check before wrapping the request with a `data` key
```
  transformer: {
    enabled: true,
      requestTransforms: {
        wrapBodyWithDataKey: true,
        ignoredRoutes: ["/api/auth/*"],
      },
     ...
    },
  },
```