### PR TITLE
chore(release): 3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json.schemastore.org/package",
 	"name": "strapi-plugin-transformer",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"description": "A plugin for Strapi Headless CMS that provides the ability to transform the API request and/or response.",
 	"scripts": {
 		"lint": "eslint . --fix",


### PR DESCRIPTION
This release adds the followings changes
- bumps upper engine limit to 20 #96 