### PR TITLE
Allow the transformer middleware for individual content types for plu…

### DIFF
--- a/server/register.js
+++ b/server/register.js
@@ -1,98 +1,128 @@
-'use strict';
+"use strict";
 
-const _ = require('lodash');
+const _ = require("lodash");
 
-const { transform } = require('./middleware/transform');
-const { getPluginService } = require('./util/getPluginService');
+const { transform } = require("./middleware/transform");
+const { getPluginService } = require("./util/getPluginService");
 
 function addTransformMiddleware(route) {
-	// ensure path exists
-	if (!_.has(route, ['config', 'middlewares'])) {
-		_.set(route, ['config', 'middlewares'], []);
-	}
+  // ensure path exists
+  if (!_.has(route, ["config", "middlewares"])) {
+    _.set(route, ["config", "middlewares"], []);
+  }
 
-	// register route middleware
-	route.config.middlewares.push((ctx, next) => transform(strapi, ctx, next));
+  // register route middleware
+  route.config.middlewares.push((ctx, next) => transform(strapi, ctx, next));
 }
 
+// Helper functions
 function isAllowableAPI({ mode, uid, filterValues }) {
-	// respect ct uid filter
-	const filterUID = _.get(filterValues, [uid], false);
-	if (mode === 'allow' && !filterUID && _.isBoolean(filterUID)) {
-		return false;
-	} else if (mode === 'deny' && filterUID && _.isBoolean(filterUID)) {
-		return false;
-	}
+  const filterUID = _.get(filterValues, [uid], false);
 
-	return true;
+  if (mode === "allow" && !filterUID && _.isBoolean(filterUID)) {
+    return false;
+  } else if (mode === "deny" && filterUID && _.isBoolean(filterUID)) {
+    return false;
+  }
+
+  return true;
 }
 
 function isAllowableMethod({ mode, uid, method, filterValues }) {
-	// respect ct uid method filter
-	const filterMethod = _.get(filterValues, [uid, method], null);
-	if (mode === 'allow' && !filterMethod && _.isBoolean(filterMethod)) {
-		return false;
-	} else if (mode === 'deny' && filterMethod && _.isBoolean(filterMethod)) {
-		return false;
-	}
+  const filterMethod = _.get(filterValues, [uid, method], null);
+  if (mode === "allow" && !filterMethod && _.isBoolean(filterMethod)) {
+    return false;
+  } else if (mode === "deny" && filterMethod && _.isBoolean(filterMethod)) {
+    return false;
+  }
 
-	return true;
+  return true;
 }
 
 function register({ strapi }) {
-	const settings = getPluginService('settingsService').get();
-	let ctFilterMode = _.get(settings, ['contentTypeFilter', 'mode'], 'none');
-	let pluginFilterMode = _.get(settings, ['plugins', 'mode'], 'allow');
-	const ctFilterUIDs = _.get(settings, ['contentTypeFilter', 'uids'], {});
-	const pluginFilterIDs = _.get(settings, ['plugins', 'ids'], {});
-	const apiTypes = ['api'];
+  const settings = getPluginService("settingsService").get();
 
-	// default uid list to all apis
-	if (_.size(ctFilterUIDs) === 0) {
-		ctFilterMode = 'none';
-	}
+  let ctFilterMode = _.get(settings, ["contentTypeFilter", "mode"], "none");
+  const pluginFilterMode = _.get(settings, ["plugins", "mode"], "allow");
 
-	// default plugins list to none
-	if (_.size(pluginFilterIDs) !== 0) {
-		apiTypes.push('plugins');
-	}
+  const ctFilterUIDs = _.get(settings, ["contentTypeFilter", "uids"], {});
+  const pluginFilterIDs = _.get(settings, ["plugins", "ids"], {});
 
-	_.forEach(apiTypes, (apiType) => {
-		const mode = apiType === 'api' ? ctFilterMode : pluginFilterMode;
-		const filterValues = apiType === 'api' ? ctFilterUIDs : pluginFilterIDs;
-		_.forEach(strapi[apiType], (api, apiName) => {
-			const uid = _.get(api, ['contentTypes', apiName, 'uid'], apiName);
-			if (!isAllowableAPI({ uid, mode, filterValues })) {
-				return;
-			}
+  const apiTypes = ["api"];
 
-			_.forEach(api.routes, (router) => {
-				// skip admin routes
-				if (router.type && router.type === 'admin') {
-					return;
-				}
+  if (_.size(ctFilterUIDs) === 0) {
+    ctFilterMode = "none";
+  }
 
-				if (router.routes) {
-					// process routes
-					_.forEach(router.routes, (route) => {
-						if (!isAllowableMethod({ uid, mode, filterValues, method: route.method })) {
-							return;
-						}
+  if (_.size(pluginFilterIDs) !== 0) {
+    apiTypes.push("plugins");
+  }
 
-						addTransformMiddleware(route);
-					});
-					return;
-				}
+  _.forEach(apiTypes, (apiType) => {
+    const mode = apiType === "api" ? ctFilterMode : pluginFilterMode;
+    const filterValues = apiType === "api" ? ctFilterUIDs : pluginFilterIDs;
 
-				if (!isAllowableMethod({ uid, mode, filterValues, method: router.method })) {
-					return;
-				}
+    _.forEach(strapi[apiType], (api, apiName) => {
+      _.forEach(api.contentTypes, (contentType, contentTypeName) => {
+        let uid;
 
-				// process route
-				addTransformMiddleware(router);
-			});
-		});
-	});
+        if (apiType === "plugins" && contentType.plugin === apiName) {
+          // Plugin content type
+          uid = contentType.uid;
+          const pluginUIDs = _.get(filterValues, [apiName, "uids"], {});
+
+          if (!isAllowableAPI({ uid, mode, filterValues: pluginUIDs })) {
+            return;
+          }
+        } else {
+          // General API content type
+          uid = contentType.uid;
+
+          if (!isAllowableAPI({ uid, mode, filterValues })) {
+            return;
+          }
+        }
+
+        _.forEach(api.routes, (router) => {
+          if (router.type && router.type === "admin") {
+            return;
+          }
+
+          if (router.routes) {
+            _.forEach(router.routes, (route) => {
+              if (
+                !isAllowableMethod({
+                  uid,
+                  mode,
+                  filterValues,
+                  method: route.method,
+                })
+              ) {
+                return;
+              }
+              // Add transform middleware to the route
+              addTransformMiddleware(route);
+            });
+            return;
+          }
+
+          if (
+            !isAllowableMethod({
+              uid,
+              mode,
+              filterValues,
+              method: router.method,
+            })
+          ) {
+            return;
+          }
+
+          // Add transform middleware to the router
+          addTransformMiddleware(router);
+        });
+      });
+    });
+  });
 }
 
-module.exports = register;
+export default register;


### PR DESCRIPTION
…gins

This adds support for allowing individual content-types to be transformed by the transformer middleware.

Example config:

```transformer: {
    enabled: true,
    config: {
      responseTransforms: {
        removeAttributesKey: true,
        removeDataKey: true,
      },
      contentTypeFilter: {
        mode: "allow",
        uids: {
          "api::blog.blog": true,
        },
      },
      plugins: {
        mode: "allow",
        ids: {
          "some-plugin": {
            mode: "allow",
            uids: {
              "plugin::some-plugin.some-content-type": true,
            },
          },
        },
      },
    },
  },```